### PR TITLE
Add Prefix Command

### DIFF
--- a/src/commands/Settings/prefix.ts
+++ b/src/commands/Settings/prefix.ts
@@ -1,0 +1,21 @@
+import { KlasaMessage, Command } from '../../imports';
+import { CommandStore } from 'klasa';
+import { GuildSettings } from '../../lib/types/settings/GuildSettings';
+
+export default class extends Command {
+
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			permissionLevel: 7,
+			usage: '[prefix:string]'
+		});
+	}
+
+	public async run(message: KlasaMessage, [prefix = '.']: [string]) {
+		await message.guild.settings.update(GuildSettings.Prefix, prefix);
+
+		return message.sendMessage(`The prefix for this server has been changed to **${prefix}**.`);
+	}
+
+
+}

--- a/src/lib/types/settings/GuildSettings.ts
+++ b/src/lib/types/settings/GuildSettings.ts
@@ -3,6 +3,7 @@ import { Snowflake } from 'discord.js';
 export namespace GuildSettings {
 	export type Followers = Snowflake[];
 	export const Followers = 'followers';
+	export const Prefix = 'prefix';
 
 	export namespace Channels {
 		export type TextChannelID = Snowflake;


### PR DESCRIPTION
<!-- Please do not open a pull request unless you have opened an issue about your Pull Request first. If there is an issue already and this solves the issue, please write Closes #xxx so that merging this Pull Request automatically closes the issue. -->

## Description
This command allows servers to easily setup a custom prefix on their server. It can be quite annoying when you have multiple bots and unable to change the prefix easily. This is just good bot practices.

## List of Changes
- Prefix command

# Screenshots of Changes
![image](https://user-images.githubusercontent.com/23035000/64078197-9734c980-cca5-11e9-96a1-d526e56d373f.png)
